### PR TITLE
バックエンドの画像ドメインをremotePatternsに追加

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,8 +3,17 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   images: {
-    // X(Twitter)とGoogleのプロフィール画像を表示するために追加
-    domains: ["lh3.googleusercontent.com"],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+      },
+      {
+        protocol: "https",
+        hostname: "ramen-ai-backend-service-943228427206.asia-northeast1.run.app",
+        pathname: "/rails/active_storage/**",
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                
  - Next.jsのImageコンポーネントで未登録ドメインの画像を表示するとレンダリングエラーになる問題を修正                                                                                                        
  - バックエンド（ramen-ai-backend-service-...run.app）のドメインをremotePatternsに追加
  - あわせて非推奨のdomainsからremotePatternsに移行                                                                                                                                                         
                                                                                                                                                                                                            
  ## Test plan                                                                                                                                                                                              
  - [ ] ラーメンのランダム表示画面で画像が表示されること
  - [ ] おすすめ画面で画像が表示されること
  - [ ] メニュー詳細画面で画像が表示されること