### PR TITLE
店舗詳細ページの追加とデザイン統一

### DIFF
--- a/src/app/api/shops/[id]/menus/route.ts
+++ b/src/app/api/shops/[id]/menus/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const MENUS_BY_SHOP: Record<number, { id: number; name: string; genre_name: string; noodle_name: string; soup_name: string; image_url: string }[]> = {
+  1: [
+    { id: 101, name: "昭和（むかし）ラーメン", genre_name: "ラーメン", noodle_name: "細麺", soup_name: "豚骨", image_url: "https://placehold.co/400x300?text=Ramen+1" },
+    { id: 102, name: "博多ラーメン",           genre_name: "ラーメン", noodle_name: "極細麺", soup_name: "豚骨", image_url: "https://placehold.co/400x300?text=Ramen+2" },
+    { id: 103, name: "チャーシュー麺",         genre_name: "ラーメン", noodle_name: "細麺", soup_name: "豚骨", image_url: "https://placehold.co/400x300?text=Ramen+3" },
+  ],
+  2: [
+    { id: 201, name: "一蘭ラーメン",           genre_name: "ラーメン", noodle_name: "細麺", soup_name: "豚骨", image_url: "https://placehold.co/400x300?text=Ichiran" },
+  ],
+  3: [
+    { id: 301, name: "黒亭ラーメン",           genre_name: "ラーメン", noodle_name: "中細麺", soup_name: "豚骨", image_url: "https://placehold.co/400x300?text=Kokutei" },
+    { id: 302, name: "黒亭チャーシュー麺",     genre_name: "ラーメン", noodle_name: "中細麺", soup_name: "豚骨", image_url: "https://placehold.co/400x300?text=Kokutei+2" },
+  ],
+};
+
+const DEFAULT_MENUS = [
+  { id: 901, name: "醤油ラーメン", genre_name: "ラーメン", noodle_name: "中細麺", soup_name: "醤油", image_url: "https://placehold.co/400x300?text=Shoyu" },
+  { id: 902, name: "味噌ラーメン", genre_name: "ラーメン", noodle_name: "太麺",   soup_name: "味噌", image_url: "https://placehold.co/400x300?text=Miso" },
+];
+
+const PER_PAGE = 20;
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const { searchParams } = request.nextUrl;
+  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
+
+  const allMenus = MENUS_BY_SHOP[Number(id)] ?? DEFAULT_MENUS;
+  const totalCount = allMenus.length;
+  const totalPages = Math.max(1, Math.ceil(totalCount / PER_PAGE));
+  const currentPage = Math.min(page, totalPages);
+  const offset = (currentPage - 1) * PER_PAGE;
+  const menus = allMenus.slice(offset, offset + PER_PAGE);
+
+  return NextResponse.json(
+    { menus },
+    {
+      headers: {
+        "Current-Page": String(currentPage),
+        "Page-Items": String(PER_PAGE),
+        "Total-Pages": String(totalPages),
+        "Total-Count": String(totalCount),
+      },
+    }
+  );
+}

--- a/src/app/api/shops/[id]/route.ts
+++ b/src/app/api/shops/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+
+const ALL_SHOPS = [
+  { id: 1,  name: "九州 筑豊ラーメン山小屋",       address: "佐賀県嬉野市嬉野町大字下宿甲４００２−４",       google_map_url: "https://maps.app.goo.gl/BvuQTxGsmKLJ68yL9" },
+  { id: 2,  name: "博多ラーメン 一蘭",              address: "福岡県福岡市博多区博多駅前２−１",              google_map_url: "https://maps.app.goo.gl/example2" },
+  { id: 3,  name: "熊本ラーメン 黒亭",              address: "熊本県熊本市中央区上通町１−１",              google_map_url: "https://maps.app.goo.gl/example3" },
+];
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const shop = ALL_SHOPS.find((s) => s.id === Number(id)) ?? {
+    id: Number(id),
+    name: "サンプルラーメン店",
+    address: "東京都新宿区1-1-1",
+    google_map_url: "https://maps.app.goo.gl/example",
+  };
+
+  return NextResponse.json({ shop });
+}

--- a/src/app/shops/[id]/page.tsx
+++ b/src/app/shops/[id]/page.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import Image from "next/image";
+import { apiService } from "@/lib/api-client";
+
+type Shop = {
+  id: number;
+  name: string;
+  address: string;
+  google_map_url: string;
+};
+
+type Menu = {
+  id: number;
+  name: string;
+  genre_name: string;
+  noodle_name: string;
+  soup_name: string;
+  image_url: string | null;
+  shop: Shop;
+};
+
+type Pagination = {
+  current_page: number;
+  per_page: number;
+  total_count: number;
+  total_pages: number;
+};
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default function ShopDetailPage({ params }: PageProps) {
+  const router = useRouter();
+  const [shop, setShop] = useState<Shop | null>(null);
+  const [menus, setMenus] = useState<Menu[]>([]);
+  const [pagination, setPagination] = useState<Pagination | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [shopId, setShopId] = useState<string | null>(null);
+
+  useEffect(() => {
+    params.then((p) => setShopId(p.id));
+  }, [params]);
+
+  useEffect(() => {
+    if (!shopId) return;
+
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const [shopData, menusData] = await Promise.all([
+          apiService.getShopDetail(shopId),
+          apiService.getShopMenus(shopId, currentPage),
+        ]);
+        setShop(shopData.shop ?? shopData);
+        setMenus(menusData.menus);
+        setPagination(menusData.pagination);
+      } catch (err) {
+        console.error("店舗詳細の取得に失敗しました:", err);
+        setError("店舗情報の取得に失敗しました");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [shopId, currentPage]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
+          <p className="text-gray-600">店舗情報を取得中...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !shop) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-center">
+          <p className="text-red-500 mb-4">{error ?? "店舗が見つかりませんでした"}</p>
+          <Button variant="outline" onClick={() => router.back()}>
+            ← 戻る
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-2xl mx-auto px-4 py-6">
+        {/* 店舗情報 */}
+        <div className="bg-white rounded-xl shadow-sm p-5 mb-6">
+          <h1 className="text-lg font-bold text-gray-800 mb-1">{shop.name}</h1>
+          <p className="text-sm text-gray-600 mb-3">📍 {shop.address}</p>
+          <a
+            href={shop.google_map_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-blue-500 hover:underline"
+          >
+            Google マップで見る
+          </a>
+        </div>
+
+        {/* メニュー一覧 */}
+        <h2 className="text-lg font-bold text-gray-800 mb-3">
+          メニュー一覧
+          {pagination && (
+            <span className="text-sm font-normal text-gray-500 ml-2">
+              （{pagination.total_count}件）
+            </span>
+          )}
+        </h2>
+
+        {menus.length === 0 ? (
+          <div className="bg-white rounded-xl shadow-sm p-8 text-center text-gray-500">
+            メニュー情報がありません
+          </div>
+        ) : (
+          <>
+            <ul className="space-y-4">
+              {menus.map((menu) => (
+                <li key={menu.id} className="bg-white rounded-xl shadow-sm overflow-hidden">
+                  {menu.image_url && (
+                    <div className="relative w-full h-48">
+                      <Image
+                        src={menu.image_url}
+                        alt={menu.name}
+                        fill
+                        sizes="(max-width: 672px) 100vw, 672px"
+                        className="object-cover"
+                      />
+                    </div>
+                  )}
+                  <div className="p-4">
+                    <h3 className="font-bold text-gray-800 mb-1">{menu.name}</h3>
+                    <p className="text-sm text-gray-500">
+                      {menu.genre_name} · {menu.soup_name}スープ · {menu.noodle_name}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ul>
+
+            {pagination && pagination.total_pages > 1 && (
+              <div className="flex items-center justify-center gap-2 mt-8">
+                <button
+                  onClick={() => setCurrentPage((p) => p - 1)}
+                  disabled={currentPage === 1}
+                  className="px-4 py-2 rounded-lg border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  前へ
+                </button>
+
+                {Array.from({ length: pagination.total_pages }, (_, i) => i + 1).map((page) => (
+                  <button
+                    key={page}
+                    onClick={() => setCurrentPage(page)}
+                    className={`w-9 h-9 rounded-lg text-sm font-medium ${
+                      page === currentPage
+                        ? "bg-blue-500 text-white"
+                        : "border border-gray-300 text-gray-700 hover:bg-gray-100"
+                    }`}
+                  >
+                    {page}
+                  </button>
+                ))}
+
+                <button
+                  onClick={() => setCurrentPage((p) => p + 1)}
+                  disabled={currentPage === pagination.total_pages}
+                  className="px-4 py-2 rounded-lg border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  次へ
+                </button>
+              </div>
+            )}
+          </>
+        )}
+
+        <div className="mt-8">
+          <Button variant="outline" onClick={() => router.back()} className="w-full">
+            ← 戻る
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/shops/page.tsx
+++ b/src/app/shops/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import { apiService } from "@/lib/api-client";
@@ -20,6 +21,7 @@ type Pagination = {
 };
 
 export default function Shops() {
+  const router = useRouter();
   const [shops, setShops] = useState<Shop[]>([]);
   const [pagination, setPagination] = useState<Pagination | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
@@ -89,13 +91,18 @@ export default function Shops() {
           <>
             <ul className="space-y-4">
               {shops.map((shop) => (
-                <li key={shop.id} className="bg-white rounded-xl shadow-sm p-5">
+                <li
+                  key={shop.id}
+                  onClick={() => router.push(`/shops/${shop.id}`)}
+                  className="bg-white rounded-xl shadow-sm p-5 cursor-pointer hover:shadow-md transition-shadow"
+                >
                   <h2 className="text-lg font-bold text-gray-800 mb-1">{shop.name}</h2>
-                  <p className="text-sm text-gray-600 mb-3">{shop.address}</p>
+                  <p className="text-sm text-gray-600 mb-3">📍 {shop.address}</p>
                   <a
                     href={shop.google_map_url}
                     target="_blank"
                     rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
                     className="text-sm text-blue-500 hover:underline"
                   >
                     Google マップで見る

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -134,4 +134,27 @@ export const apiService = {
       return { shops: [], pagination: null };
     }
   },
+
+  getShopDetail: async (id: string) => {
+    const response = await secureApiClient.get(`/shops/${id}`);
+    return response.data;
+  },
+
+  getShopMenus: async (id: string, page: number = 1) => {
+    const response = await secureApiClient.get(`/shops/${id}/menus`, { params: { page } });
+    const headers = response.headers;
+    const menus = (response.data.menus ?? []).map((menu: MenuType & { image_url: string }) => ({
+      ...menu,
+      image_url: convertImageUrl(menu.image_url),
+    }));
+    return {
+      menus,
+      pagination: {
+        current_page: parseInt(headers["current-page"] ?? "1", 10),
+        per_page: parseInt(headers["page-items"] ?? "20", 10),
+        total_pages: parseInt(headers["total-pages"] ?? "1", 10),
+        total_count: parseInt(headers["total-count"] ?? "0", 10),
+      },
+    };
+  },
 };


### PR DESCRIPTION
- 店舗一覧のカードクリックで詳細ページへ遷移
- 店舗詳細ページを新規作成（店舗情報＋メニュー一覧）
- getShopDetail / getShopMenus を apiService に追加
- モックAPI（/api/shops/[id], /api/shops/[id]/menus）を追加
- 一覧・詳細で住所・Googleマップリンクのデザインを統一
- 詳細ページの戻るボタンを1つに統一