### PR TITLE
fix: APIクライアントのタイムアウトを10秒から30秒に延長

### DIFF
--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -20,7 +20,7 @@ type MenuType = {
 
 export const secureApiClient = axios.create({
   baseURL: API_URL,
-  timeout: 10000,
+  timeout: 30000,
   headers: {
     "Content-Type": "application/json",
     Accept: "application/json",


### PR DESCRIPTION
FEで"timeout of 10000ms exceeded"が発生していたため、
secureApiClientのタイムアウト設定を10000msから30000msに変更。